### PR TITLE
Fix for instance-based views

### DIFF
--- a/django_pdb/middleware.py
+++ b/django_pdb/middleware.py
@@ -52,10 +52,19 @@ class PdbMiddleware(object):
         if not type_pdb:
             return
 
-        filename = inspect.getsourcefile(view_func)
+        try:
+            filename = inspect.getsourcefile(view_func)
+        except TypeError:
+            if hasattr(view_func, "__class__"):
+                filename = inspect.getsourcefile(view_func.__class__)
+                lines, lineno = inspect.getsourcelines(view_func.__class__)
+            else:
+                raise
+        else:
+            lines, lineno = inspect.getsourcelines(view_func)
+
         basename = os.path.basename(filename)
         dirname = os.path.basename(os.path.dirname(filename))
-        lines, lineno = inspect.getsourcelines(view_func)
         temporary = True
         cond = None
         funcname = view_func.__name__


### PR DESCRIPTION
When debugging instance-based views (such as those from [django-haystack](https://github.com/toastdriven/django-haystack)), a traceback is encountered:

```
Traceback:
File "/usr/lib/python2.7/dist-packages/django/core/handlers/base.py" in get_response
  105.                         response = middleware_method(request, callback, callback_args, callback_kwargs)
File "/home/joel/src/django-pdb/django_pdb/middleware.py" in process_view
  55.         filename = inspect.getsourcefile(view_func)
File "/usr/lib/python2.7/inspect.py" in getsourcefile
  444.     filename = getfile(object)
File "/usr/lib/python2.7/inspect.py" in getfile
  420.                     'function, traceback, frame, or code object'.format(object))

Exception Type: TypeError at /discover/
Exception Value: <search.views.ProductSearchView object at 0x7fce1c84bfd0> is not a module, class, method, function, traceback, frame, or code object
```

To fix this error, inspect the class instead of the instance.
