### PR TITLE
Issue #55: Fix PdbMiddleware with django >= 4.1

### DIFF
--- a/django_pdb/middleware.py
+++ b/django_pdb/middleware.py
@@ -38,7 +38,10 @@ class PdbMiddleware(parent):
         unless settings.DEBUG is also True. Otherwise, this middleware
         is always active.
         """
-        self.get_response = get_response
+        if parent is object:  # compatibility
+            self.get_response = get_response
+        else:
+            super().__init__(get_response)
         if debug_only and not settings.DEBUG:
             raise MiddlewareNotUsed()
 


### PR DESCRIPTION
I just call the `super` when the parent is not `object`. That should fix the compat with django 4.1 and any further django change to middleware.